### PR TITLE
Fixes issue #20: allow overriding default colours

### DIFF
--- a/src/styles/md-steppers.scss
+++ b/src/styles/md-steppers.scss
@@ -9,8 +9,8 @@ $steppers-paginator-width: $baseline-grid * 4 !default;
 $steppers-step-width: $baseline-grid * 12 !default;
 $steppers-header-height: 72px !default;
 
-$steppers-md-primary-color: rgb(16,108,200);
-$steppers-md-warn-color: rgb(255,87,34);
+$steppers-md-primary-color: rgb(16,108,200) !default;
+$steppers-md-warn-color: rgb(255,87,34) !default;
 
 @mixin pie-clearfix {
     &:after {


### PR DESCRIPTION
Added !default flag to $steppers-md-primary-color and $steppers-md-warn-color variables in md-steppers.scss file in order to allow overriding default colours. Ideally all variables should be moved to a separate file.
